### PR TITLE
Increase TTL to 3600 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ hook.go currently implements support for the Linode DNS API: it will retrieve an
 Developed and tested on Ubuntu Linux 14.04 with Go 1.6 (earlier versions may work: we're not doing anything special here). Make sure that Go is installed and the workspace is setup with GOPATH properly defined. Then:
 
 - git clone https://github.com/IdeaSynthesis/letsencrypt-dns01-hooks $GOPATH/src/github.com/IdeaSynthesis/letsencrypt-dns01-hooks
-- cd $GOPATH/src/github.com/IdeaSynthesis.com/letsencrypt-dns01-hooks
+- cd $GOPATH/src/github.com/IdeaSynthesis/letsencrypt-dns01-hooks
 - go install
 
 ## Usage Requirements

--- a/hook.go
+++ b/hook.go
@@ -128,7 +128,7 @@ func main(){
 		}
 		q.Add("DomainID", fmt.Sprintf("%v", domainid))
 		q.Add("Target", token)
-		q.Add("TTL_sec", "60")
+		q.Add("TTL_sec", "3600")
 		req.URL.RawQuery = q.Encode()
 
 		resp, _ = client.Do(req)


### PR DESCRIPTION
Asking for 60 seconds rounds up to Linode's minimum of 300 seconds, which is too short, resulting in failed DNS challenges.

Specifying anything between 301 and 3600 rounds up to 3600. So ask for 3600.
